### PR TITLE
Add Volcano gang scheduling support and adapter to AI conformance tests

### DIFF
--- a/test/e2e/run-e2e-gcp.sh
+++ b/test/e2e/run-e2e-gcp.sh
@@ -31,6 +31,7 @@ GCE_IMAGE_FAMILY="${GCE_IMAGE_FAMILY:-common-cu129-ubuntu-2404-nvidia-580}"
 GCE_IMAGE_PROJECT="${GCE_IMAGE_PROJECT:-deeplearning-platform-release}"
 K8S_VERSION="${K8S_VERSION:-v1.35.0}"
 GPU_OPERATOR_VERSION="${GPU_OPERATOR_VERSION:-v26.3.1}"
+VOLCANO_VERSION="${VOLCANO_VERSION:-v1.9.0}"
 GANG_SCHEDULER="${GANG_SCHEDULER:-kueue}"
 BUILD_ID="${BUILD_ID:-$(date +%s)}"
 VM_NAME="ai-conformance-e2e-${BUILD_ID}"
@@ -333,7 +334,7 @@ EOF
   kubectl wait --for=condition=Active clusterqueue/e2e-cq --timeout=60s
 elif [ "${GANG_SCHEDULER}" = "volcano" ]; then
   echo "Installing Volcano..."
-  kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.9.0/installer/volcano-development.yaml
+  kubectl apply -f "https://raw.githubusercontent.com/volcano-sh/volcano/${VOLCANO_VERSION}/installer/volcano-development.yaml"
 
   echo "Waiting for Volcano controllers to be ready..."
   kubectl rollout status deployment -n volcano-system volcano-admission --timeout=5m
@@ -348,10 +349,11 @@ REMOTE_STACK
 
 echo "Preparing go test arguments..."
 if [ "${GANG_SCHEDULER}" = "kueue" ]; then
-    GANG_LABELS="-gang-job-labels=\"kueue.x-k8s.io/queue-name=e2e-lq\""
+    GANG_LABELS="-gang-job-labels=kueue.x-k8s.io/queue-name=e2e-lq"
 else
     GANG_LABELS=""
 fi
+GANG_ARGS="-gang-scheduler-name=${GANG_SCHEDULER} ${GANG_LABELS}"
 
 echo "================================================================"
 echo "4. Executing AI Conformance Test Suite (test/)"
@@ -368,8 +370,7 @@ go test -v ./test/... \
     -accelerator-type=nvidia \
     -allocation-mode=auto \
     -gang-scheduler-namespace=ai-conformance-gang-scheduling \
-    -gang-scheduler-name=${GANG_SCHEDULER} \
-    ${GANG_LABELS} \
+    ${GANG_ARGS} \
     -json | tee _artifacts/results.json
 REMOTE_TEST
 

--- a/test/e2e/run-e2e-gcp.sh
+++ b/test/e2e/run-e2e-gcp.sh
@@ -346,6 +346,13 @@ fi
 
 REMOTE_STACK
 
+echo "Preparing go test arguments..."
+if [ "${GANG_SCHEDULER}" = "kueue" ]; then
+    GANG_LABELS="-gang-job-labels=\"kueue.x-k8s.io/queue-name=e2e-lq\""
+else
+    GANG_LABELS=""
+fi
+
 echo "================================================================"
 echo "4. Executing AI Conformance Test Suite (test/)"
 echo "================================================================"
@@ -355,13 +362,6 @@ export PATH="/usr/local/go/bin:\${HOME}/go/bin:\${PATH}"
 
 cd ~/ai-conformance
 mkdir -p _artifacts
-
-echo "Preparing go test arguments..."
-if [ "${GANG_SCHEDULER}" = "kueue" ]; then
-    GANG_LABELS="-gang-job-labels=\"kueue.x-k8s.io/queue-name=e2e-lq\""
-else
-    GANG_LABELS=""
-fi
 
 echo "Running go test ./test/..."
 go test -v ./test/... \

--- a/test/e2e/run-e2e-gcp.sh
+++ b/test/e2e/run-e2e-gcp.sh
@@ -331,6 +331,17 @@ EOF
 
   echo "Waiting for ClusterQueue to be active..."
   kubectl wait --for=condition=Active clusterqueue/e2e-cq --timeout=60s
+elif [ "${GANG_SCHEDULER}" = "volcano" ]; then
+  echo "Installing Volcano..."
+  kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.9.0/installer/volcano-development.yaml
+
+  echo "Waiting for Volcano controllers to be ready..."
+  kubectl rollout status deployment -n volcano-system volcano-admission --timeout=5m
+  kubectl rollout status deployment -n volcano-system volcano-controllers --timeout=5m
+  kubectl rollout status deployment -n volcano-system volcano-scheduler --timeout=5m
+
+  echo "Creating test namespace..."
+  kubectl create namespace ai-conformance-gang-scheduling --dry-run=client -o yaml | kubectl apply -f -
 fi
 
 REMOTE_STACK
@@ -345,12 +356,20 @@ export PATH="/usr/local/go/bin:\${HOME}/go/bin:\${PATH}"
 cd ~/ai-conformance
 mkdir -p _artifacts
 
+echo "Preparing go test arguments..."
+if [ "${GANG_SCHEDULER}" = "kueue" ]; then
+    GANG_LABELS="-gang-job-labels=\"kueue.x-k8s.io/queue-name=e2e-lq\""
+else
+    GANG_LABELS=""
+fi
+
 echo "Running go test ./test/..."
 go test -v ./test/... \
     -accelerator-type=nvidia \
     -allocation-mode=auto \
     -gang-scheduler-namespace=ai-conformance-gang-scheduling \
-    -gang-job-labels="kueue.x-k8s.io/queue-name=e2e-lq" \
+    -gang-scheduler-name=${GANG_SCHEDULER} \
+    ${GANG_LABELS} \
     -json | tee _artifacts/results.json
 REMOTE_TEST
 

--- a/test/gang_scheduling_test.go
+++ b/test/gang_scheduling_test.go
@@ -13,7 +13,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -23,6 +26,7 @@ import (
 // Ref: https://github.com/kubernetes-sigs/ai-conformance/blob/main/kars/0053-gang-scheduling/README.md
 func TestGangScheduling(t *testing.T) {
 	clientset := getClientset(t)
+	dynamicClient := getDynamicClient(t)
 
 	ctx := context.Background()
 	namespace := *gangSchedulerNamespace
@@ -67,6 +71,7 @@ func TestGangScheduling(t *testing.T) {
 		})
 
 		t.Logf("Creating positive test job %s...", jobName)
+		applyVolcanoAdapter(ctx, t, dynamicClient, job)
 		if _, err := clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create positive job: %v", err)
 		}
@@ -84,6 +89,7 @@ func TestGangScheduling(t *testing.T) {
 		})
 
 		t.Logf("Creating negative test job %s...", jobName)
+		applyVolcanoAdapter(ctx, t, dynamicClient, job)
 		if _, err := clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create negative job: %v", err)
 		}
@@ -253,4 +259,51 @@ func buildResourceList(cpuReq, memReq string) corev1.ResourceList {
 		corev1.ResourceCPU:    resource.MustParse(cpuReq),
 		corev1.ResourceMemory: resource.MustParse(memReq),
 	}
+}
+
+func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynamic.Interface, job *batchv1.Job) {
+	if *gangSchedulerName != "volcano" {
+		return
+	}
+
+	t.Logf("Applying Volcano adapter for job %s...", job.Name)
+
+	// 1. Mutate Job
+	job.Spec.Template.Spec.SchedulerName = "volcano"
+	if job.Spec.Template.Annotations == nil {
+		job.Spec.Template.Annotations = make(map[string]string)
+	}
+	job.Spec.Template.Annotations["scheduling.k8s.io/group-name"] = job.Name
+	job.Spec.Template.Annotations["scheduling.volcano.sh/group-name"] = job.Name
+
+	// 2. Create PodGroup
+	podGroup := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "scheduling.volcano.sh/v1beta1",
+			"kind":       "PodGroup",
+			"metadata": map[string]interface{}{
+				"name":      job.Name,
+				"namespace": job.Namespace,
+			},
+			"spec": map[string]interface{}{
+				"minMember": int64(*job.Spec.Parallelism),
+				"queue":     "default",
+			},
+		},
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "scheduling.volcano.sh",
+		Version:  "v1beta1",
+		Resource: "podgroups",
+	}
+
+	if _, err := dynamicClient.Resource(gvr).Namespace(job.Namespace).Create(ctx, podGroup, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Volcano PodGroup for job %s: %v", job.Name, err)
+	}
+
+	t.Cleanup(func() {
+		t.Logf("Cleaning up Volcano PodGroup %s...", job.Name)
+		_ = dynamicClient.Resource(gvr).Namespace(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{})
+	})
 }

--- a/test/gang_scheduling_test.go
+++ b/test/gang_scheduling_test.go
@@ -65,13 +65,16 @@ func TestGangScheduling(t *testing.T) {
 		jobName := "pos-job"
 		job := buildGenericGangSchedulingJob(namespace, jobName, 2, "100m", "128Mi")
 
+		t.Logf("Creating positive test job %s...", jobName)
+		if err := applyGangSchedulerAdapter(ctx, t, dynamicClient, job); err != nil {
+			t.Fatalf("Failed to apply gang scheduler adapter: %v", err)
+		}
+
 		t.Cleanup(func() {
 			deletePolicy := metav1.DeletePropagationBackground
 			_ = clientset.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 		})
 
-		t.Logf("Creating positive test job %s...", jobName)
-		applyVolcanoAdapter(ctx, t, dynamicClient, job)
 		if _, err := clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create positive job: %v", err)
 		}
@@ -83,13 +86,16 @@ func TestGangScheduling(t *testing.T) {
 		jobName := "neg-job"
 		job := buildGenericGangSchedulingJob(namespace, jobName, 1000, "100m", "128Mi")
 
+		t.Logf("Creating negative test job %s...", jobName)
+		if err := applyGangSchedulerAdapter(ctx, t, dynamicClient, job); err != nil {
+			t.Fatalf("Failed to apply gang scheduler adapter: %v", err)
+		}
+
 		t.Cleanup(func() {
 			deletePolicy := metav1.DeletePropagationBackground
 			_ = clientset.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 		})
 
-		t.Logf("Creating negative test job %s...", jobName)
-		applyVolcanoAdapter(ctx, t, dynamicClient, job)
 		if _, err := clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create negative job: %v", err)
 		}
@@ -261,11 +267,20 @@ func buildResourceList(cpuReq, memReq string) corev1.ResourceList {
 	}
 }
 
-func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynamic.Interface, job *batchv1.Job) {
-	if *gangSchedulerName != "volcano" {
-		return
+func applyGangSchedulerAdapter(ctx context.Context, t *testing.T, dynamicClient dynamic.Interface, job *batchv1.Job) error {
+	switch *gangSchedulerName {
+	case "volcano":
+		applyVolcanoAdapter(ctx, t, dynamicClient, job)
+		return nil
+	case "kueue":
+		// Kueue handles gang scheduling automatically via annotations/labels, no extra API resources needed here.
+		return nil
+	default:
+		return fmt.Errorf("unsupported gang-scheduler-name %q", *gangSchedulerName)
 	}
+}
 
+func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynamic.Interface, job *batchv1.Job) {
 	t.Logf("Applying Volcano adapter for job %s...", job.Name)
 
 	// 1. Mutate Job
@@ -275,6 +290,11 @@ func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynami
 	}
 	job.Spec.Template.Annotations["scheduling.k8s.io/group-name"] = job.Name
 	job.Spec.Template.Annotations["scheduling.volcano.sh/group-name"] = job.Name
+
+	var minMember int64 = 1
+	if job.Spec.Parallelism != nil {
+		minMember = int64(*job.Spec.Parallelism)
+	}
 
 	// 2. Create PodGroup
 	podGroup := &unstructured.Unstructured{
@@ -286,7 +306,7 @@ func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynami
 				"namespace": job.Namespace,
 			},
 			"spec": map[string]interface{}{
-				"minMember": int64(*job.Spec.Parallelism),
+				"minMember": minMember,
 				"queue":     "default",
 			},
 		},
@@ -304,6 +324,9 @@ func applyVolcanoAdapter(ctx context.Context, t *testing.T, dynamicClient dynami
 
 	t.Cleanup(func() {
 		t.Logf("Cleaning up Volcano PodGroup %s...", job.Name)
-		_ = dynamicClient.Resource(gvr).Namespace(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{})
+		err := dynamicClient.Resource(gvr).Namespace(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Failed to clean up Volcano PodGroup %s: %v", job.Name, err)
+		}
 	})
 }

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -18,6 +18,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	nodeutil "k8s.io/component-helpers/node/util"
@@ -63,6 +64,7 @@ var (
 	gangSchedulerNamespace *string
 	gangJobLabels          *string
 	gangNegativeWindow     *time.Duration
+	gangSchedulerName      *string
 	acceleratorConfigs     = map[string]AcceleratorConfig{
 		"nvidia": {
 			DeviceClass:      "gpu.nvidia.com",
@@ -88,6 +90,8 @@ func init() {
 		"Comma-separated key=value labels to apply to the generic gang scheduling Job (e.g. kueue.x-k8s.io/queue-name=e2e-lq).")
 	gangNegativeWindow = flag.Duration("gang-negative-window", 30*time.Second,
 		"Duration to observe the negative gang scheduling test job to verify no pods are partially scheduled.")
+	gangSchedulerName = flag.String("gang-scheduler-name", "",
+		"Name of the gang scheduler being tested (e.g. 'volcano'). Used to apply adapter logic if required.")
 }
 
 // getClientset creates a Kubernetes clientset using the kubeconfig flag.
@@ -150,6 +154,23 @@ func deleteNamespaceAndWait(ctx context.Context, t *testing.T, c kubernetes.Inte
 		return fmt.Errorf("namespace %s was not deleted before the cleanup deadline%s: %w", namespace, lastAPIErrorSuffix(lastAPIError), err)
 	}
 	return nil
+}
+
+// getDynamicClient creates a dynamic Kubernetes client using the kubeconfig flag.
+func getDynamicClient(t *testing.T) dynamic.Interface {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if *kubeconfig != "" {
+		loadingRules.ExplicitPath = *kubeconfig
+	}
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		t.Fatalf("Error building kubeconfig: %v", err)
+	}
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error creating dynamic client: %v", err)
+	}
+	return client
 }
 
 // lookupAcceleratorConfig resolves an -accelerator-type value to its config,

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -92,7 +92,7 @@ func init() {
 	gangNegativeWindow = flag.Duration("gang-negative-window", 30*time.Second,
 		"Duration to observe the negative gang scheduling test job to verify no pods are partially scheduled.")
 	gangSchedulerName = flag.String("gang-scheduler-name", "",
-		"Name of the gang scheduler being tested (e.g. 'volcano'). Used to apply adapter logic if required.")
+		"Name of the gang scheduler being tested (currently supports: 'kueue' or 'volcano'). Used to apply adapter logic if required.")
 }
 
 // getClientConfig creates a REST client config using the kubeconfig flag.

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
@@ -94,9 +95,8 @@ func init() {
 		"Name of the gang scheduler being tested (e.g. 'volcano'). Used to apply adapter logic if required.")
 }
 
-// getClientset creates a Kubernetes clientset using the kubeconfig flag.
-// Shared helper to avoid duplicating kubeconfig loading across test files.
-func getClientset(t *testing.T) kubernetes.Interface {
+// getClientConfig creates a REST client config using the kubeconfig flag.
+func getClientConfig(t *testing.T) *rest.Config {
 	t.Helper()
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if *kubeconfig != "" {
@@ -106,7 +106,14 @@ func getClientset(t *testing.T) kubernetes.Interface {
 	if err != nil {
 		t.Fatalf("Error building kubeconfig: %v", err)
 	}
-	clientset, err := kubernetes.NewForConfig(config)
+	return config
+}
+
+// getClientset creates a Kubernetes clientset using the kubeconfig flag.
+// Shared helper to avoid duplicating kubeconfig loading across test files.
+func getClientset(t *testing.T) kubernetes.Interface {
+	t.Helper()
+	clientset, err := kubernetes.NewForConfig(getClientConfig(t))
 	if err != nil {
 		t.Fatalf("Error creating kubernetes client: %v", err)
 	}
@@ -158,15 +165,8 @@ func deleteNamespaceAndWait(ctx context.Context, t *testing.T, c kubernetes.Inte
 
 // getDynamicClient creates a dynamic Kubernetes client using the kubeconfig flag.
 func getDynamicClient(t *testing.T) dynamic.Interface {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if *kubeconfig != "" {
-		loadingRules.ExplicitPath = *kubeconfig
-	}
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
-	if err != nil {
-		t.Fatalf("Error building kubeconfig: %v", err)
-	}
-	client, err := dynamic.NewForConfig(config)
+	t.Helper()
+	client, err := dynamic.NewForConfig(getClientConfig(t))
 	if err != nil {
 		t.Fatalf("Error creating dynamic client: %v", err)
 	}


### PR DESCRIPTION
## Description
Following up on the initial gang scheduling tests implemented for Kueue, this PR adds support for testing [Volcano](https://volcano.sh/) as a gang scheduler in the AI Conformance test suite.

Due to Volcano's architecture, when a standard `batch/v1` Job is created, Volcano's Mutating Admission Webhook automatically generates a shadow `PodGroup` with `minMember: 1`, bypassing custom strict `minMember` requirements. This PR introduces an adapter to seamlessly override this behavior during the tests.

## Changes
- **Added `-gang-scheduler-name` flag**: Introduced a new CLI flag in `util_test.go` to specify the scheduler being tested (e.g. `volcano`).
- **Dynamic `PodGroup` Management**: Added an `applyVolcanoAdapter` helper in `gang_scheduling_test.go` that intercepts the generic `batch/v1` Job creation. When testing Volcano, it uses the dynamic client to programmatically create and clean up the `PodGroup` CRD alongside the job.
- **Webhook Override**: The adapter mutates the Job template to explicitly include the `scheduling.k8s.io/group-name` and `scheduling.volcano.sh/group-name` annotations pointing to our custom `PodGroup`. This overrides the Volcano mutating webhook, ensuring Volcano respects our strict `minMember: 1000` requirement for the negative tests.
- **E2E Script Update**: Updated `run-e2e-gcp.sh` to optionally install Volcano components when `GANG_SCHEDULER=volcano` is specified, removing the need for external policy engines or manual pre-provisioning.

## Testing
- Successfully verified both the `PositiveGangScheduling` and `NegativeGangScheduling` tests locally against a `kind` cluster with Volcano installed.
- Confirmed that the negative test pods successfully remain suspended/pending without partial scheduling when the `minMember` constraint cannot be met.
