### PR TITLE
test: add custom help menu to categorize test flags

### DIFF
--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,0 +1,60 @@
+package conformance
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of Kubernetes AI Conformance tests:\n\n")
+		fmt.Fprintf(os.Stderr, "These tests require specific flags depending on the capability being tested.\n\n")
+
+		var globalFlags, autoscalerFlags, gangFlags, goTestFlags []*flag.Flag
+
+		flag.VisitAll(func(f *flag.Flag) {
+			if strings.HasPrefix(f.Name, "test.") {
+				goTestFlags = append(goTestFlags, f)
+			} else if strings.HasPrefix(f.Name, "autoscaler-") {
+				autoscalerFlags = append(autoscalerFlags, f)
+			} else if strings.HasPrefix(f.Name, "gang-") {
+				gangFlags = append(gangFlags, f)
+			} else {
+				globalFlags = append(globalFlags, f)
+			}
+		})
+
+		printFlags := func(title string, flags []*flag.Flag) {
+			if len(flags) == 0 {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "%s:\n", title)
+			for _, f := range flags {
+				// Use exactly the same format as Go's default flag printing
+				_, _ = fmt.Fprintf(os.Stderr, "  -%s", f.Name)
+				name, usage := flag.UnquoteUsage(f)
+				if len(name) > 0 {
+					_, _ = fmt.Fprintf(os.Stderr, " %s", name)
+				}
+				_, _ = fmt.Fprintf(os.Stderr, "\n    \t%s", strings.ReplaceAll(usage, "\n", "\n    \t"))
+				if f.DefValue != "" {
+					_, _ = fmt.Fprintf(os.Stderr, " (default %q)", f.DefValue)
+				}
+				_, _ = fmt.Fprintf(os.Stderr, "\n")
+			}
+			fmt.Fprintf(os.Stderr, "\n")
+		}
+
+		printFlags("Global Suite Flags (Apply to all tests)", globalFlags)
+		printFlags("Accelerator Cluster Autoscaling Flags (TestAcceleratorClusterAutoscaling)", autoscalerFlags)
+		printFlags("Gang Scheduling Flags (TestGangScheduling)", gangFlags)
+
+		fmt.Fprintf(os.Stderr, "Standard Go Test Flags (e.g. -v, -run, -timeout, -short):\n")
+		fmt.Fprintf(os.Stderr, "  Run 'go help testflag' for detailed documentation of standard flags.\n")
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Adds a `TestMain()` function that overrides the default `flag.Usage` to categorize all test flags.

Previously, running `go test ./test -args -help` produced an unorganized alphabetical list containing both standard Go test flags (like `-test.v`) and test-specific flags mixed together. This made it difficult to discern which flags were relevant for specific tests (e.g., Cluster Autoscaling vs. Gang Scheduling).

This change explicitly groups our custom suite flags by their capabilities while still directing users to the standard `go test` flags.

### Before
```text
Usage of test.test:
  -accelerator-type string
    	The type of accelerator to test... (default "nvidia")
  -allocation-mode string
    	How test pods request accelerators... (default "auto")
  -autoscaler-node-pool-label string
    	Node label identifying the accelerator pool to test...
  ...
  -test.alloc_space
  ...
  -test.bench
  ...
```

### After
```text
Usage of Kubernetes AI Conformance tests:

These tests require specific flags depending on the capability being tested.

Global Suite Flags (Apply to all tests):
  -accelerator-type string
    	The type of accelerator to test... (default "nvidia")
  -allocation-mode string
    	How test pods request accelerators... (default "auto")
  -kubeconfig string
    	absolute path to the kubeconfig file

Accelerator Cluster Autoscaling Flags (TestAcceleratorClusterAutoscaling):
  -autoscaler-node-pool-label string
    	Node label identifying the accelerator pool to test...
  -autoscaler-pending-timeout duration
    	How long to wait for the scale-up trigger Pod... (default "2m0s")
  ...

Gang Scheduling Flags (TestGangScheduling):
  -gang-job-labels string
    	Comma-separated key=value labels...
  ...

Standard Go Test Flags (e.g. -v, -run, -timeout, -short):
  Run 'go help testflag' for detailed documentation of standard flags.
```